### PR TITLE
extend documentation

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -13,6 +13,12 @@
 npm i @nestjs-cognito/auth
 ```
 
+Don't forget to install the [peerDependency](https://github.com/Lokicoule/nestjs-cognito/blob/%40nestjs-cognito/core%400.2.8/packages/core/package.json#L39): `@aws-sdk/client-cognito-identity-provider`
+
+```bash
+npm i @aws-sdk/client-cognito-identity-provider
+```
+
 ## Configuration
 
 ### Options params


### PR DESCRIPTION
It took me a while to figure out why my project with `@nestjs-cognito/auth` on production does not work as on my local machine, guess what? On local I do have dev dependencies which includes the peerDependency `¯\_(ツ)_/¯`

I believe to extend the existing documentation with a small hint for installing peerDependencies could make sense.