### PR TITLE
Fix deprecated way of passing exception cause to UnauthorizedException

### DIFF
--- a/packages/auth/lib/abstract.guard.ts
+++ b/packages/auth/lib/abstract.guard.ts
@@ -43,7 +43,7 @@ export abstract class AbstractGuard implements CanActivate {
 
       return this.onValidate(this.getAuthenticatedUser(request));
     } catch (error) {
-      throw new UnauthorizedException(error, "Authentication failed.");
+      throw new UnauthorizedException("Authentication failed.", { cause: error });
     }
   }
 


### PR DESCRIPTION
The current method of passing an exception cause is deprecated according to this warning:

```
WARN DEPRECATED! Passing the error cause as the first argument to HttpException constructor is deprecated. You should use the "options" parameter instead: new HttpException("message", 400, { cause: new Error("Some Error") }) 
```

This has the additional impact that the `UnauthorizedException` gets interpreted as `Internal server error` on invalid or expired tokens.  