### PR TITLE
fix(lerna): remove 'useWorkspaces' option

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,6 @@
   "useNx": false,
   "version": "independent",
   "npmClient": "yarn",
-  "useWorkspaces": true,
   "changelog": {
     "labels": {
       "feature": "Features",


### PR DESCRIPTION
```
lerna notice cli v7.0.0
lerna ERR! ECONFIGWORKSPACES The "useWorkspaces" option has been removed. By default lerna will resolve your packages using your package manager's workspaces configuration.
```