### PR TITLE
fix(core): add `additionalProperties` to `CognitoModuleOptions`

### DIFF
--- a/packages/core/lib/interfaces/cognito-module.options.ts
+++ b/packages/core/lib/interfaces/cognito-module.options.ts
@@ -4,6 +4,7 @@ import {
   CognitoJwtVerifierProperties,
   CognitoJwtVerifierSingleUserPool,
 } from "aws-jwt-verify/cognito-verifier";
+import { JwksCache } from "aws-jwt-verify/jwk";
 
 /**
  * @type CognitoJwtVerifier - The CognitoJwtVerifier instance
@@ -23,7 +24,11 @@ export type CognitoJwtVerifier =
  */
 export type CognitoModuleOptions = {
   identityProvider?: CognitoIdentityProviderClientConfig;
-  jwtVerifier?: CognitoJwtVerifierProperties;
+  jwtVerifier?: CognitoJwtVerifierProperties & {
+    additionalProperties?: {
+      jwksCache: JwksCache;
+    };
+  };
 };
 
 /**

--- a/packages/core/lib/utils/cognito.utils.ts
+++ b/packages/core/lib/utils/cognito.utils.ts
@@ -19,7 +19,9 @@ import { CognitoModuleOptions } from "../interfaces/cognito-module.options";
 export const createCognitoJwtVerifierInstance = (
   cognitoModuleOptions: CognitoModuleOptions
 ): CognitoJwtVerifierSingleUserPool<CognitoJwtVerifierProperties> => {
-  if (!Boolean(cognitoModuleOptions.jwtVerifier)) {
+  const jwtVerifier = cognitoModuleOptions.jwtVerifier;
+
+  if (!jwtVerifier) {
     return null;
   }
 
@@ -29,27 +31,31 @@ export const createCognitoJwtVerifierInstance = (
     userPoolId,
     clientId,
     tokenUse = "id",
+    additionalProperties,
     ...others
-  } = cognitoModuleOptions.jwtVerifier;
+  } = jwtVerifier;
 
   if (!Boolean(userPoolId)) {
     logger.warn(
-      `The userPoolId is missing in the CognitoJwtVerifier configuration`
+      "The userPoolId is missing in the CognitoJwtVerifier configuration"
     );
   }
 
   if (!Boolean(clientId)) {
     logger.warn(
-      `The clientId is missing in the CognitoJwtVerifier configuration`
+      "The clientId is missing in the CognitoJwtVerifier configuration"
     );
   }
 
-  return CognitoJwtVerifierAWS.create({
-    clientId,
-    userPoolId,
-    tokenUse,
-    ...others,
-  });
+  return CognitoJwtVerifierAWS.create(
+    {
+      clientId,
+      userPoolId,
+      tokenUse,
+      ...others,
+    },
+    additionalProperties
+  );
 };
 
 /**


### PR DESCRIPTION
This commit adds a new option, `additionalProperties`, to the `CognitoModuleOptions` interface in the `cognito-module.options.ts` file. This option allows the `jwtVerifier` to be overridden with additional properties.

Refs: #515