### PR TITLE
update authentication guard documentation examples

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -115,14 +115,14 @@ export class DogsController {
 }
 ```
 
-#### `AuthenticationGard`
+#### `AuthenticationGuard`
 
 You can also use the `AuthenticationGuard` to secure individual routes or endpoint.
 
 To use the `AuthenticationGuard`, you'll need to use the `@UseGuards` decorator:
 
 ```ts
-import { Authentication } from "@nestjs-cognito/auth";
+import { AuthenticationGuard } from "@nestjs-cognito/auth";
 import { UseGuards } from "@nestjs/common";
 
 @Controller("dogs")


### PR DESCRIPTION
This is not a critical issue, but it will help others who are referencing the documentation while implementing this technology.

- Updates Authentication Guard example to include the import of `AuthenticationGuard` instead of `Authentication`
- Fixes a typo documentation