### PR TITLE
HTTP only cookie support on graphql-ws subscription

### DIFF
--- a/packages/core/lib/utils/cognito.utils.spec.ts
+++ b/packages/core/lib/utils/cognito.utils.spec.ts
@@ -3,6 +3,7 @@ import { CognitoModuleOptions } from "../interfaces/cognito-module.options";
 import {
   createCognitoIdentityProviderInstance,
   createCognitoJwtVerifierInstance,
+  parseCookies,
 } from "./cognito.utils";
 
 describe("CognitoUtils", () => {
@@ -103,4 +104,19 @@ it("should return null when neither jwtVerifier nor jwtRsaVerifier is provided",
   const cognitoJwtVerifier = createCognitoJwtVerifierInstance(options);
 
   expect(cognitoJwtVerifier).toBeNull();
+});
+
+describe("parseCookies", () => {
+  it("should parse cookies", () => {
+    const cookies = "foo=bar; baz=qux";
+
+    const parsedCookies = parseCookies(cookies);
+
+    expect(parsedCookies).toEqual({ foo: "bar", baz: "qux" });
+  });
+
+  it("should return an empty object when no cookies are provided", () => {
+    const parsedCookies = parseCookies();
+    expect(parsedCookies).toEqual({});
+  });
 });

--- a/packages/core/lib/utils/cognito.utils.ts
+++ b/packages/core/lib/utils/cognito.utils.ts
@@ -94,3 +94,13 @@ function buildConfigurationFromOptions(
     ...options,
   };
 }
+
+export const parseCookies = (cookies?: string) => {
+  if (!cookies) return {};
+
+  return cookies.split(";").reduce((acc, cookie) => {
+    const [key, value] = cookie.split("=");
+    acc[key.trim()] = value;
+    return acc;
+  }, {});
+}

--- a/packages/graphql/lib/authentication/authentication.guard.ts
+++ b/packages/graphql/lib/authentication/authentication.guard.ts
@@ -1,17 +1,29 @@
 import { ExecutionContext, Injectable } from "@nestjs/common";
 import { GqlExecutionContext } from "@nestjs/graphql";
 import { AuthenticationGuard as CoreAuthenticationGuard } from "@nestjs-cognito/auth";
+import { parseCookies } from "@nestjs-cognito/core";
 
 @Injectable()
 export class AuthenticationGuard extends CoreAuthenticationGuard {
   /**
-   * Get the request from the context
+   * Get the request from the context.
+   *
    * @param {ExecutionContext} context - The context
    * @returns {Request} - The request
    * @memberof AuthenticationGuard
    */
   public getRequest(context: ExecutionContext): any {
     const ctx = GqlExecutionContext.create(context).getContext();
-    return ctx.req;
+
+    const request = ctx.req;
+
+    // Support graphql-ws by extracting cookies from the extra property
+    const wsCookieString = request?.extra?.request?.headers?.cookie;
+
+    if (wsCookieString) {
+      request.cookies = parseCookies(wsCookieString);
+    }
+
+    return request;
   }
 }


### PR DESCRIPTION
Hi @Lokicoule,

We are building out our application and bumped into, what we believe, might be some missing functionality to transparently support HTTP only cookies with `graphql-ws` and `subscriptions.`

When using graphql-ws and subscriptions, we see that HTTP only cookies are missing at the point of authentication and it fails.

We traced it down to the AuthenticationGuard in the `graphql` package. A GQL context is build and then a request is returned. 

```
public getRequest(context: ExecutionContext): any {
    const ctx = GqlExecutionContext.create(context).getContext();
    return ctx.req;
  }
 ```

Downstream authentication expects a `cookies` property to be present, which in case of HTTP is ✅ , but not for websockets 🤔 ...

From CookieJwtExtractor:

```
hasAuthenticationInfo(request: any): boolean {
    const cookies = request?.cookies || {};
    const token = cookies?.[this.cookieName];

    return Boolean(token && token.trim());
  }
```

After some digging we found out that `graphql-ws` is passing the cookie string on some `extra` field deep inside the context :

```
ctx.request?.extra?.request?.headers?.cookie;
```

We took a shot on how this can be supported in the PR. Feel free to take a different route. 
As a temporary workaround we've copied the existing CookieJwtExtractor and do the additional cookie parsing / extraction 

```typescript
export class CookieJwtExtractor implements CognitoJwtExtractor {
    private readonly cookieName: string;

    /**
     * Creates a new cookie-based JWT extractor.
     * @param cookieName - The name of the cookie containing the JWT token. Defaults to 'access_token'
     */
    constructor(cookieName: string = 'access_token') {
        this.cookieName = cookieName;
    }

    /**
     * Checks if the request has authentication information in the specified cookie.
     * @param request - The request object (must have cookies property)
     * @returns True if the cookie is present and not empty
     */
    hasAuthenticationInfo(request: any): boolean {
        const cookies = request?.cookies || this.extractCookiesFromWs(request)
        const token = cookies?.[this.cookieName];

        return Boolean(token && token.trim());
    }

    extractCookiesFromWs(request:any): Record<string,string| undefined> | undefined  {
        const cookieString = request?.extra?.request?.headers?.cookie
        return cookieString ? cookie.parse(cookieString) : undefined
    }
    /**
     * Extracts the JWT token from the specified cookie.
     * @param request - The request object (must have cookies property)
     * @returns The JWT token string or null if not found
     */
    getAuthorizationToken(request: any): string | null {

        const cookies = request?.cookies || this.extractCookiesFromWs(request)
        const token = cookies?.[this.cookieName];

        if (!token || !token.trim()) {
            return null;
        }

        return token.trim();
    }
}
```

