### PR TITLE
feat(auth,graphql): add specialized decorators for Cognito token types

### DIFF
--- a/packages/auth/lib/errors/cognito-token-type-mismatch.error.ts
+++ b/packages/auth/lib/errors/cognito-token-type-mismatch.error.ts
@@ -1,0 +1,9 @@
+/**
+ * Exception thrown when a Cognito token type doesn't match the expected type
+ */
+export class CognitoTokenTypeMismatchError extends Error {
+  constructor(expectedType: string, actualType: string) {
+    super(`Expected ${expectedType} token but received ${actualType} token`);
+    this.name = 'CognitoTokenTypeMismatchError';
+  }
+}

--- a/packages/auth/lib/errors/index.ts
+++ b/packages/auth/lib/errors/index.ts
@@ -1,0 +1,1 @@
+export * from "./cognito-token-type-mismatch.error";

--- a/packages/auth/lib/index.ts
+++ b/packages/auth/lib/index.ts
@@ -2,7 +2,9 @@ export * from "./abstract.guard";
 export * from "./authentication";
 export * from "./authorization";
 export * from "./cognito-auth.module";
+export * from "./errors";
 export * from "./user";
 export * from "./utils";
 export * from "./validators";
 export * from "./whitelist";
+

--- a/packages/auth/lib/user/decorators/cognito-user.decorator.ts
+++ b/packages/auth/lib/user/decorators/cognito-user.decorator.ts
@@ -1,34 +1,56 @@
 import { createParamDecorator, ExecutionContext } from "@nestjs/common";
 import { COGNITO_JWT_PAYLOAD_CONTEXT_PROPERTY } from "../user.constants";
+import { extractCognitoUserData } from "./cognito-user.helper";
 
 /**
- * Decorator that can be used to inject the cognito user into a controller.
- * @param {string} [propertyName] The name of the property to inject the user into.
+ * Core decorator logic shared by all Cognito user decorators
+ */
+export function createCognitoUserDecorator(
+  validateTokenType?: 'access' | 'id',
+  getRequest?: (ctx: ExecutionContext) => any
+) {
+  return createParamDecorator(
+    (data: string | string[], ctx: ExecutionContext) => {
+      const request = getRequest ? getRequest(ctx) : ctx.switchToHttp().getRequest();
+      const payload = request[COGNITO_JWT_PAYLOAD_CONTEXT_PROPERTY];
+
+      return extractCognitoUserData(payload, validateTokenType, data);
+    },
+  );
+}
+
+/**
+ * Generic decorator that can be used to inject the cognito user into a controller.
+ * This decorator is agnostic to token type and works with both access and ID tokens.
+ * 
+ * @param {string | string[]} [propertyName] The name of the property to inject the user into.
  * @returns {(target: object, key: string | symbol, descriptor: TypedPropertyDescriptor<any>) => any}
  * @example @CognitoUser() user: CognitoJwtPayload
  * @example @CognitoUser("username") username: string
  * @example @CognitoUser(["cognito:username", "email"]) { username, email }: { username: string, email: string }
  */
-export const CognitoUser = createParamDecorator(
-  (data: string | string[], ctx: ExecutionContext) => {
-    const request = ctx.switchToHttp().getRequest();
-    const payload = request[COGNITO_JWT_PAYLOAD_CONTEXT_PROPERTY];
+export const CognitoUser = createCognitoUserDecorator();
 
-    if (!Boolean(payload)) {
-      return undefined;
-    }
+/**
+ * Specialized decorator for Access Token payloads.
+ * This decorator is specifically designed for access tokens and provides better type safety.
+ * 
+ * @param {string | string[]} [propertyName] The name of the property to inject the user into.
+ * @returns {(target: object, key: string | symbol, descriptor: TypedPropertyDescriptor<any>) => any}
+ * @example @CognitoAccessUser() user: CognitoAccessTokenPayload
+ * @example @CognitoAccessUser("username") username: string
+ * @example @CognitoAccessUser(["username", "scope"]) { username, scope }: { username: string, scope: string }
+ */
+export const CognitoAccessUser = createCognitoUserDecorator('access');
 
-    if (!data) {
-      return payload;
-    }
-
-    if (Array.isArray(data)) {
-      return data.reduce((result, key) => {
-        result[key] = payload[`cognito:${key}`] || payload[key];
-        return result;
-      }, {});
-    }
-
-    return payload[`cognito:${data}`] || payload[data];
-  },
-);
+/**
+ * Specialized decorator for ID Token payloads.
+ * This decorator is specifically designed for ID tokens and provides better type safety.
+ * 
+ * @param {string | string[]} [propertyName] The name of the property to inject the user into.
+ * @returns {(target: object, key: string | symbol, descriptor: TypedPropertyDescriptor<any>) => any}
+ * @example @CognitoIdUser() user: CognitoIdTokenPayload
+ * @example @CognitoIdUser("cognito:username") username: string
+ * @example @CognitoIdUser(["cognito:username", "email"]) { username, email }: { username: string, email: string }
+ */
+export const CognitoIdUser = createCognitoUserDecorator('id');

--- a/packages/auth/lib/user/decorators/cognito-user.helper.spec.ts
+++ b/packages/auth/lib/user/decorators/cognito-user.helper.spec.ts
@@ -1,0 +1,58 @@
+import type { CognitoJwtPayload } from "@nestjs-cognito/core";
+import { CognitoTokenTypeMismatchError } from "../../errors/cognito-token-type-mismatch.error";
+import { extractCognitoUserData } from "./cognito-user.helper";
+
+describe("extractCognitoUserData", () => {
+  const mockAccessTokenPayload: CognitoJwtPayload = {
+    token_use: "access",
+    username: "testuser",
+    scope: "api/read",
+  } as unknown as CognitoJwtPayload;
+
+  const mockIdTokenPayload: CognitoJwtPayload = {
+    token_use: "id",
+    "cognito:username": "testuser",
+    email: "test@example.com",
+  } as unknown as CognitoJwtPayload;
+
+  it("should return undefined when payload is undefined", () => {
+    expect(extractCognitoUserData(undefined)).toBeUndefined();
+  });
+
+  it("should return the full payload when no data is specified", () => {
+    const result = extractCognitoUserData(mockAccessTokenPayload);
+    expect(result).toEqual(mockAccessTokenPayload);
+  });
+
+  describe("property extraction", () => {
+    it("should extract a single property", () => {
+      expect(extractCognitoUserData(mockAccessTokenPayload, undefined, "username")).toBe("testuser");
+    });
+
+    it("should extract property with cognito: prefix fallback", () => {
+      expect(extractCognitoUserData(mockIdTokenPayload, undefined, "username")).toBe("testuser");
+    });
+
+    it("should extract multiple properties as an object", () => {
+      const result = extractCognitoUserData(mockIdTokenPayload, undefined, ["username", "email"]);
+      expect(result).toEqual({
+        username: "testuser",
+        email: "test@example.com",
+      });
+    });
+  });
+
+  describe("token type validation", () => {
+    it.each([
+      ["access", mockAccessTokenPayload],
+      ["id", mockIdTokenPayload],
+    ] as const)("should not throw when %s token type matches", (expectedType, payload) => {
+      expect(() => extractCognitoUserData(payload, expectedType)).not.toThrow();
+    });
+
+    it("should throw CognitoTokenTypeMismatchError when token type doesn't match", () => {
+      expect(() => extractCognitoUserData(mockAccessTokenPayload, "id"))
+        .toThrow(new CognitoTokenTypeMismatchError("id", "access"));
+    });
+  });
+});

--- a/packages/auth/lib/user/decorators/cognito-user.helper.ts
+++ b/packages/auth/lib/user/decorators/cognito-user.helper.ts
@@ -1,0 +1,37 @@
+import type { CognitoJwtPayload } from "@nestjs-cognito/core";
+import { CognitoTokenTypeMismatchError } from "../../errors/cognito-token-type-mismatch.error";
+
+/**
+ * Extracts user data from a Cognito JWT payload
+ * @param payload The JWT payload
+ * @param expectedTokenType Optional token type to validate against
+ * @param data The property name(s) to extract
+ * @returns The extracted data or the full payload
+ * @throws CognitoTokenTypeMismatchError if token type validation fails
+ */
+export function extractCognitoUserData(
+  payload: CognitoJwtPayload | undefined,
+  expectedTokenType?: 'access' | 'id',
+  data?: string | string[]
+): any {
+  if (!Boolean(payload)) {
+    return undefined;
+  }
+
+  if (expectedTokenType && payload.token_use !== expectedTokenType) {
+    throw new CognitoTokenTypeMismatchError(expectedTokenType, payload.token_use);
+  }
+
+  if (!data) {
+    return payload;
+  }
+
+  if (Array.isArray(data)) {
+    return data.reduce((result, key) => {
+      result[key] = payload[`cognito:${key}`] || payload[key];
+      return result;
+    }, {});
+  }
+
+  return payload[`cognito:${data}`] || payload[data];
+}

--- a/packages/auth/lib/user/index.ts
+++ b/packages/auth/lib/user/index.ts
@@ -2,3 +2,4 @@ export * from "./decorators";
 export * from "./user.builder";
 export * from "./user.constants";
 export * from "./user.model";
+

--- a/packages/auth/lib/user/user.mapper.ts
+++ b/packages/auth/lib/user/user.mapper.ts
@@ -8,8 +8,6 @@ export class UserMapper {
     USERNAME: "User must have a username or client ID",
   };
 
-
-
   public static fromCognitoJwtPayload(
     payload: CognitoJwtPayload,
   ): User {

--- a/packages/core/lib/interfaces/cognito-module.options.ts
+++ b/packages/core/lib/interfaces/cognito-module.options.ts
@@ -6,16 +6,36 @@ import type {
 } from "aws-jwt-verify/cognito-verifier";
 import type { JwksCache } from "aws-jwt-verify/jwk";
 import type {
+  CognitoAccessTokenPayload as AwsCognitoAccessTokenPayload,
+  CognitoIdTokenPayload as AwsCognitoIdTokenPayload,
+  CognitoJwtPayload as AwsCognitoJwtPayload
+} from 'aws-jwt-verify/jwt-model';
+import type {
   JwtVerifierMultiIssuer as JwtRsaVerifierMultiIssuer,
   JwtVerifierMultiProperties as JwtRsaVerifierMultiProperties,
   JwtVerifierProperties as JwtRsaVerifierProperties,
   JwtVerifierSingleIssuer as JwtRsaVerifierSingleIssuer,
   VerifyProperties,
 } from "aws-jwt-verify/jwt-verifier";
-import type { CognitoJwtPayload as AwsCognitoJwtPayload } from 'aws-jwt-verify/jwt-model';
 import type { CognitoJwtExtractor } from './cognito-jwt-extractor.interface';
 
 export type CognitoJwtPayload = Prettify<AwsCognitoJwtPayload>;
+export type CognitoAccessTokenPayload = Prettify<AwsCognitoAccessTokenPayload>;
+export type CognitoIdTokenPayload = Prettify<AwsCognitoIdTokenPayload>;
+
+/**
+ * Type guard to check if a payload is an access token
+ */
+export function isAccessTokenPayload(payload: CognitoJwtPayload): payload is CognitoAccessTokenPayload {
+  return payload.token_use === 'access';
+}
+
+/**
+ * Type guard to check if a payload is an ID token
+ */
+export function isIdTokenPayload(payload: CognitoJwtPayload): payload is CognitoIdTokenPayload {
+  return payload.token_use === 'id';
+}
 
 /**
  * Represents a type that can be used as a Cognito JWT RSA verifier.


### PR DESCRIPTION
Add @CognitoAccessUser and @CognitoIdUser decorators with runtime validation for better type safety when working with different Cognito JWT token types.

Changes:
- Add CognitoAccessTokenPayload and CognitoIdTokenPayload types in @nestjs-cognito/core
- Add isAccessTokenPayload() and isIdTokenPayload() type guards
- Add @CognitoAccessUser and @CognitoIdUser decorators for REST controllers
- Add @GqlCognitoAccessUser and @GqlCognitoIdUser decorators for GraphQL resolvers
- Refactor decorator logic using shared createCognitoUserDecorator() factory
- Add CognitoTokenTypeMismatchError for token type validation errors
- Add comprehensive test coverage for token extraction and validation

Resolves #1445